### PR TITLE
Add `WinningOutcomeId`

### DIFF
--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPredictionEnd.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPredictionEnd.cs
@@ -11,6 +11,10 @@ namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel
     public class ChannelPredictionEnd : ChannelPredictionBase
     {
         /// <summary>
+        /// ID of the winning outcome.
+        /// </summary>
+        public string WinningOutcomeId { get; set; } = string.Empty;
+        /// <summary>
         /// The status of the Channel Points Prediction. Valid values are resolved and canceled.
         /// </summary>
         public string Status { get; set; } = string.Empty;


### PR DESCRIPTION
Fix for https://github.com/TwitchLib/TwitchLib.EventSub.Websockets/issues/12

I don't see anywhere that you have to define the `winning_outcome_id` name, apologies if I've missed that