### PR TITLE
Add Channel Points Automatic Reward Redemption Add classes

### DIFF
--- a/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public sealed class AutomaticRedemptionReward
 {
-
     /// <summary>
     /// The type of reward. One of:
     /// ssingle_message_bypass_sub_mode

--- a/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
@@ -1,4 +1,5 @@
 ﻿namespace TwitchLib.EventSub.Core.Models.ChannelPoints;
+
 /// <summary>
 /// Basic information about the reward that was automatically redeemed, at the time it was redeemed.
 /// </summary>
@@ -18,9 +19,8 @@ public sealed class AutomaticRedemptionReward
     /// The reward cost.
     /// </summary>
     public int Cost { get; set; }
-
     /// <summary>
     /// Optional. Emote that was unlocked.
     /// </summary>
-    public UnlockedEmote? UnlockedEmote { get; set; } = new();
+    public UnlockedEmote? UnlockedEmote { get; set; }
 }

--- a/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelPoints/AutomaticRedemptionReward.cs
@@ -1,0 +1,26 @@
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelPoints;
+/// <summary>
+/// Basic information about the reward that was automatically redeemed, at the time it was redeemed.
+/// </summary>
+public sealed class AutomaticRedemptionReward
+{
+
+    /// <summary>
+    /// The type of reward. One of:
+    /// ssingle_message_bypass_sub_mode
+    /// send_highlighted_message
+    /// random_sub_emote_unlock
+    /// chosen_sub_emote_unlock
+    /// chosen_modified_sub_emote_unlock
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+    /// <summary>
+    /// The reward cost.
+    /// </summary>
+    public int Cost { get; set; }
+
+    /// <summary>
+    /// Optional. Emote that was unlocked.
+    /// </summary>
+    public UnlockedEmote? UnlockedEmote { get; set; } = new();
+}

--- a/TwitchLib.EventSub.Core/Models/ChannelPoints/UnlockedEmote.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelPoints/UnlockedEmote.cs
@@ -1,0 +1,14 @@
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelPoints;
+/// <summary>
+/// Represents a unlocked emote
+/// </summary>
+public sealed class UnlockedEmote {
+    /// <summary>
+    /// The emote ID.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>
+    /// The human readable emote token.
+    /// </summary>
+    public string Name {  get; set; } = string.Empty;
+}

--- a/TwitchLib.EventSub.Core/Models/ChannelPoints/UnlockedEmote.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelPoints/UnlockedEmote.cs
@@ -1,8 +1,10 @@
 ﻿namespace TwitchLib.EventSub.Core.Models.ChannelPoints;
+
 /// <summary>
 /// Represents a unlocked emote
 /// </summary>
-public sealed class UnlockedEmote {
+public sealed class UnlockedEmote 
+{
     /// <summary>
     /// The emote ID.
     /// </summary>

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmoteFragment.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmoteFragment.cs
@@ -1,4 +1,5 @@
 ﻿namespace TwitchLib.EventSub.Core.Models.Chat;
+
 /// <summary>
 /// A Fragment of a emote that holds additional information
 /// </summary>

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmoteFragment.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmoteFragment.cs
@@ -1,0 +1,19 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Chat;
+/// <summary>
+/// A Fragment of a emote that holds additional information
+/// </summary>
+public sealed class ChatMessageEmoteFragment
+{
+    /// <summary>
+    /// The emote ID.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>
+    /// The index of where the Emote starts in the text.
+    /// </summary>
+    public int Begin { get; set; }
+    /// <summary>
+    /// The index of where the Emote ends in the text.
+    /// </summary>
+    public int End { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TwitchLib.EventSub.Core.Models.Chat;
+﻿namespace TwitchLib.EventSub.Core.Models.Chat;
 
 /// <summary>
 /// Represents a chat message with emotes fragments

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
@@ -11,7 +11,6 @@ public sealed class ChatMessageEmotes
     /// The text of the chat message.
     /// </summary>
     public string Text { get; set; } = string.Empty;
-
     /// <summary>
     /// An array that includes the emote ID and start and end positions for where the emote appears in the text.
     /// </summary>

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 namespace TwitchLib.EventSub.Core.Models.Chat;
+
 /// <summary>
 /// Represents a chat message with emotes fragments
 /// </summary>
@@ -13,5 +15,5 @@ public sealed class ChatMessageEmotes
     /// <summary>
     /// An array that includes the emote ID and start and end positions for where the emote appears in the text.
     /// </summary>
-    public ChatMessageEmoteFragment[] Emotes { get; set; } = Array.Empty<ChatMessageEmoteFragment>();
+    public ChatMessageEmoteFragment[] Emotes { get; set; } = [];
 }

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatMessageEmotes.cs
@@ -1,0 +1,17 @@
+﻿using System;
+namespace TwitchLib.EventSub.Core.Models.Chat;
+/// <summary>
+/// Represents a chat message with emotes fragments
+/// </summary>
+public sealed class ChatMessageEmotes
+{
+    /// <summary>
+    /// The text of the chat message.
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// An array that includes the emote ID and start and end positions for where the emote appears in the text.
+    /// </summary>
+    public ChatMessageEmoteFragment[] Emotes { get; set; } = Array.Empty<ChatMessageEmoteFragment>();
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelAdBreakBegin.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelAdBreakBegin.cs
@@ -12,7 +12,7 @@ public sealed class ChannelAdBreakBegin
     /// <summary>
     /// Length in seconds of the mid-roll ad break requested
     /// </summary>
-    public int LengthSeconds { get; set; }
+    public int DurationSeconds { get; set; }
     /// <summary>
     /// The UTC timestamp of when the ad break began, in RFC3339 format. Note that there is potential delay between this event, when the streamer requested the ad break, and when the viewers will see ads.
     /// </summary>

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPointsAutomaticRewardRedemption.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPointsAutomaticRewardRedemption.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using TwitchLib.EventSub.Core.Models.ChannelPoints;
 using TwitchLib.EventSub.Core.Models.Chat;
+
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
 /// <summary>
 /// Channel Points Automatic Reward Redemption subscription type model
 /// <para>!! The same for all channel points redemption subscription types !!</para>

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPointsAutomaticRewardRedemption.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelPointsAutomaticRewardRedemption.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using TwitchLib.EventSub.Core.Models.ChannelPoints;
+using TwitchLib.EventSub.Core.Models.Chat;
+namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+/// <summary>
+/// Channel Points Automatic Reward Redemption subscription type model
+/// <para>!! The same for all channel points redemption subscription types !!</para>
+/// <para>Description:</para>
+/// <para>A viewer has redeemed an automatic channel points reward on the specified channel.</para>
+/// <para>A redemption of a channel points automatic reward has been updated for the specified channel.</para>
+/// </summary>
+public sealed class ChannelPointsAutomaticRewardRedemption
+{
+    /// <summary>
+    /// The ID of the Redemption.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the channel where the reward was redeemed.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The login of the channel where the reward was redeemed.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The display name of the channel where the reward was redeemed.
+    /// </summary>
+    public string BroadcasterUserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the redeeming user.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>
+    /// Display name of the user that redeemed the reward.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+    /// <summary>
+    /// Login of the user that redeemed the reward.
+    /// </summary>
+    public string UserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user input provided. Empty string if not provided.
+    /// </summary>
+    public string UserInput { get; set; } = string.Empty;
+    /// <summary>
+    /// An object that contains the user message and emote information needed to recreate the message.
+    /// </summary>
+    public ChatMessageEmotes Message { get; set; } = new();
+    /// <summary>
+    /// Basic information about the reward that was redeemed, at the time it was redeemed.
+    /// </summary>
+    public AutomaticRedemptionReward Reward { get; set; } = new();
+    /// <summary>
+    /// RFC3339 timestamp of when the reward was redeemed.
+    /// </summary>
+    public DateTimeOffset RedeemedAt { get; set; } = DateTimeOffset.MinValue;
+}


### PR DESCRIPTION
The names and scheme comes from this: https://dev.twitch.tv/docs/eventsub/eventsub-reference/#channel-points-automatic-reward-redemption-add-event

I noticed this subcription doesnt exist in the eventsub of TwitchLib, so I am doing an attempt to add the automatic reward redemption models to core, which then can be used in TwitchLib.EventSub.Websocket. 

As it is my first pull request inside of here; let me know if there are any words that should be changed or anything that I forgot to add to the models. 