### PR TITLE
[skip-ci] code cleanup and fixing comments

### DIFF
--- a/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/ChannelSuspiciousUserBase.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/ChannelSuspiciousUserBase.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 /// <summary>
 /// Channel suspicious user base class.

--- a/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/Message.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/Message.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 public sealed class SuspiciousUserMessage
 {

--- a/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragment.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragment.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 public sealed class MessageFragment
 {

--- a/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragmentCheermote.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragmentCheermote.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 public sealed class FragmentCheermote
 {
@@ -15,9 +11,9 @@ public sealed class FragmentCheermote
     /// <summary>
     /// The amount of bits cheered.
     /// </summary>
-    public int Bits { get; set; } = 0;
+    public int Bits { get; set; }
     /// <summary>
     /// The tier level of the cheermote.
     /// </summary>
-    public int Tier { get; set; } = 0;
+    public int Tier { get; set; }
 }

--- a/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragmentEmote.cs
+++ b/TwitchLib.EventSub.Core/Models/ChannelSuspiciousUser/MessageFragmentEmote.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿namespace TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 public sealed class FragmentEmote
 {

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatPayItForward.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatPayItForward.cs
@@ -7,6 +7,8 @@ namespace TwitchLib.EventSub.Core.Models.Chat;
 /// </summary>
 public sealed class ChatPayItForward
 {
+    // RecipientUser**** isn't in docs https://github.com/TwitchLib/TwitchLib.EventSub.Core/pull/20
+
     /// <summary>
     /// Optional. The user ID of the user who received the subscription. Null if not available at the time of event trigger.
     /// </summary>

--- a/TwitchLib.EventSub.Core/Models/Chat/ChatRaid.cs
+++ b/TwitchLib.EventSub.Core/Models/Chat/ChatRaid.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TwitchLib.EventSub.Core.Models.Chat;
+﻿namespace TwitchLib.EventSub.Core.Models.Chat;
 
 /// <summary>
 /// Information about the raid event. Null if notice_type is not raid.

--- a/TwitchLib.EventSub.Core/Models/GuestStar/ChannelGuestStarSessionBase.cs
+++ b/TwitchLib.EventSub.Core/Models/GuestStar/ChannelGuestStarSessionBase.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace TwitchLib.EventSub.Core.Models.GuestStar;
 
 public abstract class ChannelGuestStarSessionBase

--- a/TwitchLib.EventSub.Core/Models/Polls/ChannelPollBase.cs
+++ b/TwitchLib.EventSub.Core/Models/Polls/ChannelPollBase.cs
@@ -32,8 +32,10 @@ public class ChannelPollBase
     /// </summary>
     public PollChoice[] Choices { get; set; } = Array.Empty<PollChoice>();
     /// <summary>
+    /// Not supported.
     /// The Bits voting settings for the poll.
     /// </summary>
+    [Obsolete("Removed 2022‑09‑01")]
     public PollVotingSettings BitsVoting { get; set; } = new();
     /// <summary>
     /// The Channel Points voting settings for the poll.

--- a/TwitchLib.EventSub.Core/Models/Polls/PollChoice.cs
+++ b/TwitchLib.EventSub.Core/Models/Polls/PollChoice.cs
@@ -1,4 +1,6 @@
-﻿namespace TwitchLib.EventSub.Core.Models.Polls;
+﻿using System;
+
+namespace TwitchLib.EventSub.Core.Models.Polls;
 
 /// <summary>
 /// Defines a poll choice
@@ -14,8 +16,10 @@ public sealed class PollChoice
     /// </summary>
     public string Title { get; set; } = string.Empty;
     /// <summary>
+    /// Not used; will be set to 0.
     /// Number of votes received via Bits.
     /// </summary>
+    [Obsolete("Removed 2022‑09‑01")]
     public int? BitsVotes { get; set; }
     /// <summary>
     /// Number of votes received via Channel Points.

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionBegin.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionBegin.cs
@@ -1,5 +1,3 @@
-using System;
-using TwitchLib.EventSub.Core.Models.GuestStar;
 using TwitchLib.EventSub.Core.Models.SharedChat;
 
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionEnd.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionEnd.cs
@@ -1,5 +1,3 @@
-using System;
-using TwitchLib.EventSub.Core.Models.GuestStar;
 using TwitchLib.EventSub.Core.Models.SharedChat;
 
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionUpdate.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSharedChatSessionUpdate.cs
@@ -1,5 +1,3 @@
-using System;
-using TwitchLib.EventSub.Core.Models.GuestStar;
 using TwitchLib.EventSub.Core.Models.SharedChat;
 
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSuspiciousUserMessage.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSuspiciousUserMessage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿using TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
 

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSuspiciousUserUpdate.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelSuspiciousUserUpdate.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
+﻿using TwitchLib.EventSub.Core.Models.ChannelSuspiciousUser;
 
 namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
 

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelUnbanRequestResolve.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelUnbanRequestResolve.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel
+﻿namespace TwitchLib.EventSub.Core.SubscriptionTypes.Channel
 {
     /// <summary>
     /// Channel Unban Request Resolve subscription type model

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelVip.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Channel/ChannelVip.cs
@@ -8,27 +8,27 @@
 public sealed class ChannelVip
 {
     /// <summary>
-    /// The user ID of the new/removed moderator.
+    /// The ID of the user who was added/removed as a VIP.
     /// </summary>
     public string UserId { get; set; } = string.Empty;
     /// <summary>
-    /// The display name of the new/removed moderator.
+    /// The display name of the user who was added/removed as a VIP.
     /// </summary>
     public string UserName { get; set; } = string.Empty;
     /// <summary>
-    /// The user login of the new/removed moderator.
+    /// The login of the user who was added/removed as a VIP.
     /// </summary>
     public string UserLogin { get; set; } = string.Empty;
     /// <summary>
-    /// The requested broadcaster ID.
+    /// The ID of the broadcaster.
     /// </summary>
     public string BroadcasterUserId { get; set; } = string.Empty;
     /// <summary>
-    /// The requested broadcaster display name.
+    /// The login of the broadcaster.
     /// </summary>
     public string BroadcasterUserName { get; set; } = string.Empty;
     /// <summary>
-    /// The requested broadcaster login.
+    /// The display name of the broadcaster.
     /// </summary>
     public string BroadcasterUserLogin { get; set; } = string.Empty;
 }


### PR DESCRIPTION
fixing comments
code cleanup (unnecessary `using`, useless default values)
adding [Obsolete] attribute to deprecated things