### PR TITLE
add missing `Automod*` subscription types

### DIFF
--- a/TwitchLib.EventSub.Core/Models/Automod/AutomodData.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/AutomodData.cs
@@ -1,0 +1,17 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class AutomodData
+{
+    /// <summary>
+    /// The category of the caught message
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+    /// <summary>
+    /// The level of severity (1-4).
+    /// </summary>
+    public int Level { get; set; }
+    /// <summary>
+    /// The bounds of the text that caused the message to be caught.
+    /// </summary>
+    public Boundary[] Boundaries { get; set; } = [];
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/BlockedTerm.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/BlockedTerm.cs
@@ -1,0 +1,9 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class BlockedTerm
+{
+    /// <summary>
+    /// The list of blocked terms found in the message.
+    /// </summary>
+    public TermFound[] TermsFound { get; set; } = [];
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/Boundary.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/Boundary.cs
@@ -1,0 +1,13 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class Boundary
+{
+    /// <summary>
+    /// Index in the message for the start of the problem (0 indexed, inclusive).
+    /// </summary>
+    public int StartPos { get; set; }
+    /// <summary>
+    /// Index in the message for the end of the problem (0 indexed, inclusive).
+    /// </summary>
+    public int EndPos { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/Cheermote.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/Cheermote.cs
@@ -1,0 +1,17 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class Cheermote
+{
+    /// <summary>
+    /// The name portion of the Cheermote string that you use in chat to cheer Bits. The full Cheermote string is the concatenation of {prefix} + {number of Bits}. For example, if the prefix is “Cheer” and you want to cheer 100 Bits, the full Cheermote string is Cheer100. When the Cheermote string is entered in chat, Twitch converts it to the image associated with the Bits tier that was cheered.
+    /// </summary>
+    public string Prefix { get; set; } = string.Empty;
+    /// <summary>
+    /// The amount of bits cheered.
+    /// </summary>
+    public int Bits { get; set; }
+    /// <summary>
+    /// The tier level of the cheermote.
+    /// </summary>
+    public int Tier { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/Emote.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/Emote.cs
@@ -1,0 +1,13 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class Emote
+{
+    /// <summary>
+    /// An ID that uniquely identifies this emote.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>
+    /// An ID that identifies the emote set that the emote belongs to.
+    /// </summary>
+    public string EmoteSetId { get; set; } = string.Empty;
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/Fragment.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/Fragment.cs
@@ -1,0 +1,21 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public class Fragment
+{
+    /// <summary>
+    ///	Message text in fragment
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+    /// <summary>
+    /// One of three options: text, emote, cheermote
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+    /// <summary>
+    /// Metadata pertaining to the emote.
+    /// </summary>
+    public Emote? Emote { get; set; }
+    /// <summary>
+    /// Metadata pertaining to the cheermote.
+    /// </summary>
+    public Cheermote? Cheermote { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/Message.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/Message.cs
@@ -1,0 +1,13 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class Message
+{
+    /// <summary>
+    /// The contents of the message caught by automod.
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+    /// <summary>
+    /// Metadata surrounding the potential inappropriate fragments of the message
+    /// </summary>
+    public Fragment[] Fragments { get; set; } = [];
+}

--- a/TwitchLib.EventSub.Core/Models/Automod/TermFound.cs
+++ b/TwitchLib.EventSub.Core/Models/Automod/TermFound.cs
@@ -1,0 +1,25 @@
+﻿namespace TwitchLib.EventSub.Core.Models.Automod;
+
+public sealed class TermFound
+{
+    /// <summary>
+    /// The id of the blocked term found.
+    /// </summary>
+    public string TermId { get; set; } = string.Empty;
+    /// <summary>
+    /// The bounds of the text that caused the message to be caught.
+    /// </summary>
+    public Boundary Boundary { get; set; } = new Boundary();
+    /// <summary>
+    /// The id of the broadcaster that owns the blocked term.
+    /// </summary>
+    public string OwnerBroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster that owns the blocked term
+    /// </summary>
+    public string OwnerBroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The username of the broadcaster that owns the blocked term.
+    /// </summary>
+    public string OwnerBroadcasterUserName { get; set; } = string.Empty;
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageHold.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageHold.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Message Hold subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodMessageHold
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUseName { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s user ID.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s login name.
+    /// </summary>
+    public string UserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s display name.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the message that was flagged by automod.
+    /// </summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The body of the message.
+    /// </summary>
+    public int[] Message { get; set; } = [];
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public int Level { get; set; }
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public DateTimeOffset HeldAt { get; set; }
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageHoldV2.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageHoldV2.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using TwitchLib.EventSub.Core.Models.Automod;
+
+namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Message Hold V2 subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodMessageHoldV2
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUseName { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s user ID.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s login name.
+    /// </summary>
+    public string UserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s display name.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the message that was flagged by automod.
+    /// </summary>
+    public string MessageId { get; set; } = string.Empty;
+    /// <summary>
+    /// The body of the message.
+    /// </summary>
+    public int[] Message { get; set; } = [];
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public int Level { get; set; }
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public DateTimeOffset HeldAt { get; set; }
+    /// <summary>
+    /// Possible values are: automod, blocked_term
+    /// </summary>
+    public string Reason { get; set; } = string.Empty;
+    /// <summary>
+    /// If the message was caught by automod, this will be populated.
+    /// </summary>
+    public AutomodData? Automod { get; set; }
+    /// <summary>
+    /// If the message was caught due to a blocked term, this will be populated
+    /// </summary>
+    public BlockedTerm? BlockedTerm { get; set; }
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageUpdate.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageUpdate.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using TwitchLib.EventSub.Core.Models.Automod;
+
+namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Message Update subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodMessageUpdate
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUseName { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s user ID.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s login name.
+    /// </summary>
+    public string UserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s display name.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the moderator.
+    /// </summary>
+    public string ModeratorUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The moderator’s user name.
+    /// </summary>
+    public string ModeratorUserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the moderator.
+    /// </summary>
+    public string ModeratorUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the message that was flagged by automod.
+    /// </summary>
+    public string MessageId { get; set; } = string.Empty;
+    /// <summary>
+    /// The body of the message.
+    /// </summary>
+    public Message Message { get; set; } = new();
+    /// <summary>
+    /// The category of the message.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+    /// <summary>
+    /// The level of severity. Measured between 1 to 4.
+    /// </summary>
+    public int Level { get; set; }
+    /// <summary>
+    /// The message’s status. Possible values are: Approved, Denied, Expired
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+    /// <summary>
+    /// The timestamp of when automod saved the message.
+    /// </summary>
+    public DateTimeOffset HeldAt { get; set; }
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageUpdateV2.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodMessageUpdateV2.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using TwitchLib.EventSub.Core.Models.Automod;
+
+namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Message Update V2 subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodMessageUpdateV2
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUseName { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s user ID.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s login name.
+    /// </summary>
+    public string UserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The message sender’s display name.
+    /// </summary>
+    public string UserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the moderator.
+    /// </summary>
+    public string ModeratorUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The moderator’s user name.
+    /// </summary>
+    public string ModeratorUserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the moderator.
+    /// </summary>
+    public string ModeratorUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the message that was flagged by automod.
+    /// </summary>
+    public string MessageId { get; set; } = string.Empty;
+    /// <summary>
+    /// The body of the message.
+    /// </summary>
+    public Message Message { get; set; } = new();
+    /// <summary>
+    /// The message’s status. Possible values are: Approved, Denied, Expired
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+    /// <summary>
+    /// The timestamp of when automod saved the message.
+    /// </summary>
+    public DateTimeOffset HeldAt { get; set; }
+    /// <summary>
+    /// The reason why the message was caught. Possible values are: automod, blocked_term
+    /// </summary>
+    public string Reason { get; set; } = string.Empty;
+    /// <summary>
+    /// If the message was caught by automod, this will be populated.
+    /// </summary>
+    public AutomodData? Automod { get; set; } = new();
+    /// <summary>
+    /// If the message was caught due to a blocked term, this will be populated.
+    /// </summary>
+    public BlockedTerm BlockedTerm { get; set; } = new();
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodSettingsUpdate.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodSettingsUpdate.cs
@@ -1,0 +1,70 @@
+﻿namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Settings Update subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodSettingsUpdate
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The ID of the moderator who changed the channel settings.
+    /// </summary>
+    public string ModeratorUserId { get; set; } = string.Empty;
+    /// <summary>
+    /// The moderator’s login.
+    /// </summary>
+    public string ModeratorUserLogin { get; set; } = string.Empty;
+    /// <summary>
+    /// The moderator’s user name.
+    /// </summary>
+    public string ModeratorUserName { get; set; } = string.Empty;
+    /// <summary>
+    /// The Automod level for hostility involving name calling or insults.
+    /// </summary>
+    public int Bullying { get; set; }
+    /// <summary>
+    /// The default AutoMod level for the broadcaster. This field is null if the broadcaster has set one or more of the individual settings.
+    /// </summary>
+    public int? OverallLevel { get; set; }
+    /// <summary>
+    /// The Automod level for discrimination against disability.
+    /// </summary>
+    public int Disability { get; set; }
+    /// <summary>
+    /// The Automod level for racial discrimination.
+    /// </summary>
+    public int RaceEthnicityOrReligion { get; set; }
+    /// <summary>
+    /// The Automod level for discrimination against women.
+    /// </summary>
+    public int Misogyny { get; set; }
+    /// <summary>
+    /// The AutoMod level for discrimination based on sexuality, sex, or gender.
+    /// </summary>
+    public int SexualitySexOrGender { get; set; }
+    /// <summary>
+    /// The Automod level for hostility involving aggression.
+    /// </summary>
+    public int Aggression { get; set; }
+    /// <summary>
+    /// The Automod level for sexual content.
+    /// </summary>
+    public int SexBasedTerms { get; set; }
+    /// <summary>
+    /// The Automod level for profanity.
+    /// </summary>
+    public int Swearing { get; set; }
+}

--- a/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodTermsUpdate.cs
+++ b/TwitchLib.EventSub.Core/SubscriptionTypes/Automod/AutomodTermsUpdate.cs
@@ -1,0 +1,54 @@
+﻿namespace TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+/// <summary>
+/// Automod Terms Update subscription type model
+/// <para>Description:</para>
+/// <para></para>
+/// </summary>
+public sealed class AutomodTermsUpdate
+{
+    /// <summary>
+    /// The ID of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The login of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserLogin { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user name of the broadcaster specified in the request.
+    /// </summary>
+    public string BroadcasterUserName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The ID of the moderator who changed the channel settings.
+    /// </summary>
+    public string ModeratorUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The moderator’s login.
+    /// </summary>
+    public string ModeratorUserLogin { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The moderator’s user name.
+    /// </summary>
+    public string ModeratorUserName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The status change applied to the terms. Possible options are: add_permitted, remove_permitted, add_blocked, remove_blocked.
+    /// </summary>
+    public string Action { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Indicates whether this term was added due to an Automod message approve/deny action.
+    /// </summary>
+    public bool FromAutomod { get; set; }
+
+    /// <summary>
+    /// The list of terms that had a status change.
+    /// </summary>
+    public string[] Terms { get; set; } = [];
+}


### PR DESCRIPTION
added missing subscription type for Automod:
- Automod Message Hold (+V2)
- Automod Message Update (+V2)
- Automod Settings Update
- Automod Terms Update

[Changelog 2024-03-07 (V1)](https://dev.twitch.tv/docs/change-log/#:~:text=2024‑03‑07)
[Changelog 2024-12-05 (V2)](https://dev.twitch.tv/docs/change-log/#:~:text=2024‑12‑05)
