### PR TITLE
move EventSub EventArgs to Core project

### DIFF
--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageHoldArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageHoldArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodMessageHoldArgs : TwitchLibEventSubNotificationArgs<AutomodMessageHold>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageHoldV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageHoldV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodMessageHoldV2Args : TwitchLibEventSubNotificationArgs<AutomodMessageHoldV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodMessageUpdateArgs : TwitchLibEventSubNotificationArgs<AutomodMessageUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageUpdateV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodMessageUpdateV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodMessageUpdateV2Args : TwitchLibEventSubNotificationArgs<AutomodMessageUpdateV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodSettingsUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodSettingsUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodSettingsUpdateArgs : TwitchLibEventSubNotificationArgs<AutomodSettingsUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodTermsUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Automod/AutomodTermsUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Automod;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Automod;
+
+public class AutomodTermsUpdateArgs : TwitchLibEventSubNotificationArgs<AutomodTermsUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelAdBreakBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelAdBreakBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelAdBreakBeginArgs : TwitchLibEventSubNotificationArgs<ChannelAdBreakBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelBanArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelBanArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelBanArgs : TwitchLibEventSubNotificationArgs<ChannelBan>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelBitsUseArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelBitsUseArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelBitsUseArgs : TwitchLibEventSubNotificationArgs<ChannelBitsUse>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignDonateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignDonateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelCharityCampaignDonateArgs : TwitchLibEventSubNotificationArgs<ChannelCharityCampaignDonate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignProgressArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignProgressArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelCharityCampaignProgressArgs : TwitchLibEventSubNotificationArgs<ChannelCharityCampaignProgress>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignStartArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignStartArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelCharityCampaignStartArgs : TwitchLibEventSubNotificationArgs<ChannelCharityCampaignStart>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignStopArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCharityCampaignStopArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelCharityCampaignStopArgs : TwitchLibEventSubNotificationArgs<ChannelCharityCampaignStop>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatClearArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatClearArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatClearArgs : TwitchLibEventSubNotificationArgs<ChannelChatClear>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatClearUserMessagesArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatClearUserMessagesArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatClearUserMessagesArgs : TwitchLibEventSubNotificationArgs<ChannelChatClearUserMessages>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatMessageArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatMessageArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatMessageArgs : TwitchLibEventSubNotificationArgs<ChannelChatMessage>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatMessageDeleteArgs : TwitchLibEventSubNotificationArgs<ChannelChatMessageDelete>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatNotificationArgs : TwitchLibEventSubNotificationArgs<ChannelChatNotification>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatSettingsUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatSettingsUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatSettingsUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelChatSettingsUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatUserMessageHoldArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatUserMessageHoldArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatUserMessageHoldArgs : TwitchLibEventSubNotificationArgs<ChannelChatUserMessageHold>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatUserMessageUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelChatUserMessageUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelChatUserMessageUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelChatUserMessageUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCheerArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelCheerArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelCheerArgs : TwitchLibEventSubNotificationArgs<ChannelCheer>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelFollowArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelFollowArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelFollowArgs : TwitchLibEventSubNotificationArgs<ChannelFollow>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGoalBeginArgs : TwitchLibEventSubNotificationArgs<ChannelGoalBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGoalEndArgs : TwitchLibEventSubNotificationArgs<ChannelGoalEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalProgressArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGoalProgressArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGoalProgressArgs : TwitchLibEventSubNotificationArgs<ChannelGoalProgress>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarGuestUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarGuestUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGuestStarGuestUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelGuestStarGuestUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSessionBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSessionBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGuestStarSessionBeginArgs : TwitchLibEventSubNotificationArgs<ChannelGuestStarSessionBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSessionEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSessionEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGuestStarSessionEndArgs : TwitchLibEventSubNotificationArgs<ChannelGuestStarSessionEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSettingsUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelGuestStarSettingsUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelGuestStarSettingsUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelGuestStarSettingsUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainBeginV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainBeginV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelHypeTrainBeginV2Args : TwitchLibEventSubNotificationArgs<HypeTrainBeginV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainEndV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainEndV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelHypeTrainEndV2Args : TwitchLibEventSubNotificationArgs<HypeTrainEndV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainProgressV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelHypeTrainProgressV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelHypeTrainProgressV2Args : TwitchLibEventSubNotificationArgs<HypeTrainProgressV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModerateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModerateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelModerateArgs : TwitchLibEventSubNotificationArgs<ChannelModerate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModerateV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModerateV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelModerateV2Args : TwitchLibEventSubNotificationArgs<ChannelModerateV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModeratorArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelModeratorArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelModeratorArgs : TwitchLibEventSubNotificationArgs<ChannelModerator>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsAutomaticRewardRedemptionAddV2Args.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsAutomaticRewardRedemptionAddV2Args.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPointsAutomaticRewardRedemptionAddV2Args : TwitchLibEventSubNotificationArgs<ChannelPointsAutomaticRewardRedemptionV2>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsAutomaticRewardRedemptionArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsAutomaticRewardRedemptionArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPointsAutomaticRewardRedemptionArgs : TwitchLibEventSubNotificationArgs<ChannelPointsAutomaticRewardRedemption>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsCustomRewardArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsCustomRewardArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPointsCustomRewardArgs : TwitchLibEventSubNotificationArgs<ChannelPointsCustomReward>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsCustomRewardRedemptionArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPointsCustomRewardRedemptionArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPointsCustomRewardRedemptionArgs : TwitchLibEventSubNotificationArgs<ChannelPointsCustomRewardRedemption>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPollBeginArgs : TwitchLibEventSubNotificationArgs<ChannelPollBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPollEndArgs : TwitchLibEventSubNotificationArgs<ChannelPollEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollProgressArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPollProgressArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPollProgressArgs : TwitchLibEventSubNotificationArgs<ChannelPollProgress>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPredictionBeginArgs : TwitchLibEventSubNotificationArgs<ChannelPredictionBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPredictionEndArgs : TwitchLibEventSubNotificationArgs<ChannelPredictionEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionLockArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionLockArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPredictionLockArgs : TwitchLibEventSubNotificationArgs<ChannelPredictionLock>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionProgressArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelPredictionProgressArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelPredictionProgressArgs : TwitchLibEventSubNotificationArgs<ChannelPredictionProgress>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelRaidArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelRaidArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelRaidArgs : TwitchLibEventSubNotificationArgs<ChannelRaid>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSharedChatSessionBeginArgs : TwitchLibEventSubNotificationArgs<ChannelSharedChatSessionBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSharedChatSessionEndArgs : TwitchLibEventSubNotificationArgs<ChannelSharedChatSessionEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSharedChatSessionUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSharedChatSessionUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelSharedChatSessionUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShieldModeBeginArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShieldModeBeginArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelShieldModeBeginArgs : TwitchLibEventSubNotificationArgs<ChannelShieldModeBegin>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShieldModeEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShieldModeEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelShieldModeEndArgs : TwitchLibEventSubNotificationArgs<ChannelShieldModeEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShoutoutCreateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShoutoutCreateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelShoutoutCreateArgs : TwitchLibEventSubNotificationArgs<ChannelShoutoutCreate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShoutoutReceiveArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelShoutoutReceiveArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelShoutoutReceiveArgs : TwitchLibEventSubNotificationArgs<ChannelShoutoutReceive>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscribeArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscribeArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSubscribeArgs : TwitchLibEventSubNotificationArgs<ChannelSubscribe>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionEndArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionEndArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSubscriptionEndArgs : TwitchLibEventSubNotificationArgs<ChannelSubscriptionEnd>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionGiftArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionGiftArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSubscriptionGiftArgs : TwitchLibEventSubNotificationArgs<ChannelSubscriptionGift>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionMessageArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSubscriptionMessageArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSubscriptionMessageArgs : TwitchLibEventSubNotificationArgs<ChannelSubscriptionMessage>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSuspiciousUserMessageArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSuspiciousUserMessageArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSuspiciousUserMessageArgs : TwitchLibEventSubNotificationArgs<ChannelSuspiciousUserMessage>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSuspiciousUserUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelSuspiciousUserUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelSuspiciousUserUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelSuspiciousUserUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelUnbanArgs : TwitchLibEventSubNotificationArgs<ChannelUnban>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanRequestCreateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanRequestCreateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelUnbanRequestCreateArgs : TwitchLibEventSubNotificationArgs<ChannelUnbanRequestCreate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanRequestResolveArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUnbanRequestResolveArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelUnbanRequestResolveArgs : TwitchLibEventSubNotificationArgs<ChannelUnbanRequestResolve>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelUpdateArgs : TwitchLibEventSubNotificationArgs<ChannelUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelVipArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelVipArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelVipArgs : TwitchLibEventSubNotificationArgs<ChannelVip>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelWarningAcknowledgeArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelWarningAcknowledgeArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelWarningAcknowledgeArgs : TwitchLibEventSubNotificationArgs<ChannelWarningAcknowledge>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelWarningSendArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Channel/ChannelWarningSendArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Channel;
+
+public class ChannelWarningSendArgs : TwitchLibEventSubNotificationArgs<ChannelWarningSend>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Conduit/ConduitShardDisabledArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Conduit/ConduitShardDisabledArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Conduit;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Conduit;
+
+public class ConduitShardDisabledArgs : TwitchLibEventSubNotificationArgs<ConduitShardDisabled>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Drop/DropEntitlementGrantArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Drop/DropEntitlementGrantArgs.cs
@@ -1,0 +1,7 @@
+﻿using TwitchLib.EventSub.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Drop;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Drop;
+
+public class DropEntitlementGrantArgs : TwitchLibEventSubNotificationArgs<EventSubBatchedEvent<DropEntitlementGrant>[]>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Extension/ExtensionBitsTransactionCreateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Extension/ExtensionBitsTransactionCreateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Extension;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Extension;
+
+public class ExtensionBitsTransactionCreateArgs : TwitchLibEventSubNotificationArgs<ExtensionBitsTransactionCreate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Stream/StreamOfflineArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Stream/StreamOfflineArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Stream;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Stream;
+
+public class StreamOfflineArgs : TwitchLibEventSubNotificationArgs<StreamOffline>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/Stream/StreamOnlineArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/Stream/StreamOnlineArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Stream;
+
+namespace TwitchLib.EventSub.Core.EventArgs.Stream;
+
+public class StreamOnlineArgs : TwitchLibEventSubNotificationArgs<StreamOnline>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/TwitchLibEventSubEventArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/TwitchLibEventSubEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using TwitchLib.EventSub.Core.Models;
+
+namespace TwitchLib.EventSub.Core.EventArgs;
+
+public abstract class TwitchLibEventSubEventArgs<TPayload> : System.EventArgs
+{
+    public EventSubMetadata Metadata { get; set; }
+    public TPayload Payload { get; set; }
+} 

--- a/TwitchLib.EventSub.Core/EventArgs/TwitchLibEventSubNotificationArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/TwitchLibEventSubNotificationArgs.cs
@@ -1,0 +1,7 @@
+﻿using TwitchLib.EventSub.Core.Models;
+
+namespace TwitchLib.EventSub.Core.EventArgs;
+
+public abstract class TwitchLibEventSubNotificationArgs<TEvent> 
+    : TwitchLibEventSubEventArgs<EventSubNotificationPayload<TEvent>>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/User/UserAuthorizationGrantArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/User/UserAuthorizationGrantArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.User;
+
+namespace TwitchLib.EventSub.Core.EventArgs.User;
+
+public class UserAuthorizationGrantArgs : TwitchLibEventSubNotificationArgs<UserAuthorizationGrant>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/User/UserAuthorizationRevokeArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/User/UserAuthorizationRevokeArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.User;
+
+namespace TwitchLib.EventSub.Core.EventArgs.User;
+
+public class UserAuthorizationRevokeArgs : TwitchLibEventSubNotificationArgs<UserAuthorizationRevoke>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/User/UserUpdateArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/User/UserUpdateArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.User;
+
+namespace TwitchLib.EventSub.Core.EventArgs.User;
+
+public class UserUpdateArgs : TwitchLibEventSubNotificationArgs<UserUpdate>
+{ }

--- a/TwitchLib.EventSub.Core/EventArgs/User/UserWhisperMessageArgs.cs
+++ b/TwitchLib.EventSub.Core/EventArgs/User/UserWhisperMessageArgs.cs
@@ -1,0 +1,6 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.User;
+
+namespace TwitchLib.EventSub.Core.EventArgs.User;
+
+public class UserWhisperMessageArgs : TwitchLibEventSubNotificationArgs<UserWhisperMessage>
+{ }

--- a/TwitchLib.EventSub.Core/Models/EventSubBatchedEvent.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubBatchedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace TwitchLib.EventSub.Core.Models;
+
+public class EventSubBatchedEvent<T>
+{
+    public string Id { get; set; }
+    public T Data { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/EventSubBatchedEvent.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubBatchedEvent.cs
@@ -1,7 +1,18 @@
 ﻿namespace TwitchLib.EventSub.Core.Models;
 
+/// <summary>
+/// Defining a batched EventSub event
+/// </summary>
+/// <typeparam name="T">SubscriptionType</typeparam>
 public class EventSubBatchedEvent<T>
 {
+    /// <summary>
+    /// Id of the notification event
+    /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Event data
+    /// </summary>
     public T Data { get; set; }
 }

--- a/TwitchLib.EventSub.Core/Models/EventSubMetadata.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubMetadata.cs
@@ -1,4 +1,7 @@
 ﻿namespace TwitchLib.EventSub.Core.Models;
 
+/// <summary>
+/// Defines an EventSub Metadata
+/// </summary>
 public abstract class EventSubMetadata
 { }

--- a/TwitchLib.EventSub.Core/Models/EventSubMetadata.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubMetadata.cs
@@ -1,0 +1,4 @@
+﻿namespace TwitchLib.EventSub.Core.Models;
+
+public abstract class EventSubMetadata
+{ }

--- a/TwitchLib.EventSub.Core/Models/EventSubNotificationPayload.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubNotificationPayload.cs
@@ -1,0 +1,7 @@
+﻿namespace TwitchLib.EventSub.Core.Models;
+
+public class EventSubNotificationPayload<T>
+{
+    public EventSubSubscription Subscription { get; set; }
+    public T Event { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/EventSubNotificationPayload.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubNotificationPayload.cs
@@ -1,7 +1,18 @@
 ﻿namespace TwitchLib.EventSub.Core.Models;
 
-public class EventSubNotificationPayload<T>
+/// <summary>
+/// Defines a notification payload of an EventSub notification
+/// </summary>
+/// <typeparam name="TEvent">SubscriptionType</typeparam>
+public class EventSubNotificationPayload<TEvent>
 {
+    /// <summary>
+    /// Contains subscription metadata.
+    /// </summary>
     public EventSubSubscription Subscription { get; set; }
-    public T Event { get; set; }
+
+    /// <summary>
+    /// The event information.
+    /// </summary>
+    public TEvent Event { get; set; }
 }

--- a/TwitchLib.EventSub.Core/Models/EventSubSubscription.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubSubscription.cs
@@ -3,15 +3,50 @@ using System.Collections.Generic;
 
 namespace TwitchLib.EventSub.Core.Models;
 
+/// <summary>
+/// Defines an EventSub Subscription
+/// </summary>
 public class EventSubSubscription
 {
     public string Id { get; set; }
+
+    /// <summary>
+    /// The subscription type name.
+    /// </summary>
     public string Type { get; set; }
+
+    /// <summary>
+    /// The subscription type version.
+    /// </summary>
     public string Version { get; set; }
+
+    /// <summary>
+    /// The status of the subscription.
+    /// </summary>
     public string Status { get; set; }
+
+    /// <summary>
+    /// Subscription-specific parameters. The parameters inside this object differ by subscription type and may differ by version.
+    /// </summary>
     public Dictionary<string, string> Condition { get; set; }
+
+    /// <summary>
+    /// An object that contains information about the transport used for notifications.
+    /// </summary>
     public EventSubTransport Transport { get; set; }
+
+    /// <summary>
+    /// Whether batching is enabled for the subscription.
+    /// </summary>
     public bool IsBatchingEnabled { get; set; }
+
+    /// <summary>
+    /// The date and time that the subscription was created.
+    /// </summary>
     public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// How much the subscription counts against your limit.
+    /// </summary>
     public int Cost { get; set; }
 }

--- a/TwitchLib.EventSub.Core/Models/EventSubSubscription.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubSubscription.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TwitchLib.EventSub.Core.Models;
+
+public class EventSubSubscription
+{
+    public string Id { get; set; }
+    public string Type { get; set; }
+    public string Version { get; set; }
+    public string Status { get; set; }
+    public Dictionary<string, string> Condition { get; set; }
+    public EventSubTransport Transport { get; set; }
+    public bool IsBatchingEnabled { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public int Cost { get; set; }
+}

--- a/TwitchLib.EventSub.Core/Models/EventSubTransport.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubTransport.cs
@@ -2,17 +2,34 @@
 
 namespace TwitchLib.EventSub.Core.Models;
 
+/// <summary>
+/// Defines an EventSub Subscription Transport
+/// </summary>
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class EventSubTransport
 {
+    /// <summary>
+    /// The transport method. Supported values: webhook, websocket, conduit
+    /// </summary>
     public string Method { get; set; }
+
+    /// <summary>
+    /// An ID that uniquely identifies the Conduit.
+    /// </summary>
     public string? ConduitId { get; set; }
+
+    /// <summary>
+    /// The callback URL where the notification is sent.
+    /// </summary>
     public string? Callback { get; set; }
+
+    /// <summary>
+    /// An ID that uniquely identifies the WebSocket connection.
+    /// </summary>
     public string? SessionId { get; set; }
 
     private string GetDebuggerDisplay()
     {
-
         var transportInfo = Method switch
         {
             "webhook" => Callback,

--- a/TwitchLib.EventSub.Core/Models/EventSubTransport.cs
+++ b/TwitchLib.EventSub.Core/Models/EventSubTransport.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+
+namespace TwitchLib.EventSub.Core.Models;
+
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
+public class EventSubTransport
+{
+    public string Method { get; set; }
+    public string? ConduitId { get; set; }
+    public string? Callback { get; set; }
+    public string? SessionId { get; set; }
+
+    private string GetDebuggerDisplay()
+    {
+
+        var transportInfo = Method switch
+        {
+            "webhook" => Callback,
+            "websocket" => SessionId,
+            "conduit" => ConduitId,
+            _ => "NotImplemented",
+        };
+        return $"{Method} - {transportInfo}";
+    }
+}


### PR DESCRIPTION
This PR "move" all EventSub specific EventArgs (and their required Models) from TwitchLib.EventSub.Webhooks and TwitchLib.EventSub.Websockets to TwitchLib.EventSub.Core.

I have already made a small test\* where I reflected these changes into ES.Websocket and ES.Webhook and it works.

\* I subscribed to `channel.chat.message / v1` and all required properties had some value